### PR TITLE
[FIX] 일/월별 학습 조회 & 로그아웃 API 수정, 랜덤 단어 복습 퀴즈 API 연결

### DIFF
--- a/src/apis/auth/mutations/logout.ts
+++ b/src/apis/auth/mutations/logout.ts
@@ -3,9 +3,6 @@ import type { LogoutRequest, LogoutResponse } from '@/types/auth';
 
 // 로그아웃
 export const logout = async (data: LogoutRequest): Promise<LogoutResponse> => {
-  const response = await apiClient.delete<LogoutResponse>('/api/v1/auth/refresh', {
-    data,
-  });
+  const response = await apiClient.post<LogoutResponse>('/api/v1/auth/refresh', data);
   return response.data;
 };
-

--- a/src/apis/profile.ts
+++ b/src/apis/profile.ts
@@ -5,6 +5,7 @@ import type {
   GetStatsResponse,
   GetDailyWordsRequest,
   GetDailyWordsResponse,
+  GetStreakDaysResponse,
   UpdateNicknameRequest,
   UpdateNicknameResponse,
   DeleteAccountResponse,
@@ -36,6 +37,13 @@ export const getDailyWords = async (params?: GetDailyWordsRequest): Promise<GetD
   return response.data;
 };
 
+export const getStreakDays = async (): Promise<GetStreakDaysResponse> => {
+  logger.log('📡 API Call: GET /api/v1/users/me/streak-days');
+  const response = await apiClient.get<GetStreakDaysResponse>('/api/v1/users/me/streak-days');
+  logger.log('📡 API Response:', response.data);
+  return response.data;
+};
+
 export const updateNickname = async (data: UpdateNicknameRequest): Promise<UpdateNicknameResponse> => {
   logger.log('📡 API Call: PUT /api/v1/users/me/nickname', data);
   const response = await apiClient.put<UpdateNicknameResponse>('/api/v1/users/me/nickname', data);
@@ -50,4 +58,4 @@ export const deleteAccount = async (): Promise<DeleteAccountResponse> => {
   return response.data;
 };
 
-export const profileAPI = { getProfile, getStats, getDailyWords, updateNickname, deleteAccount };
+export const profileAPI = { getProfile, getStats, getDailyWords, getStreakDays, updateNickname, deleteAccount };

--- a/src/apis/review/index.ts
+++ b/src/apis/review/index.ts
@@ -3,6 +3,7 @@ import { getSituationList } from './queries/situationList';
 import { getKitList } from './queries/kitList';
 import { getMonthlyStudy } from './queries/monthlyStudy';
 import { getDailyStudy } from './queries/dailyStudy';
+import { evaluateWords } from './mutations/evaluateWords';
 
 export const reviewAPI = {
   getRandomWords,
@@ -10,4 +11,5 @@ export const reviewAPI = {
   getKitList,
   getMonthlyStudy,
   getDailyStudy,
+  evaluateWords,
 };

--- a/src/apis/review/mutations/evaluateWords.ts
+++ b/src/apis/review/mutations/evaluateWords.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/apis/client';
+import type { WordEvaluationRequest, WordEvaluationResponse } from '@/types/review';
+
+export const evaluateWords = async (payload: WordEvaluationRequest): Promise<WordEvaluationResponse> => {
+  const response = await apiClient.post<WordEvaluationResponse>('/api/v1/kits/stages/evaluate', payload, {
+    timeout: 30000,
+  });
+  return response.data;
+};

--- a/src/apis/review/queries/dailyStudy.ts
+++ b/src/apis/review/queries/dailyStudy.ts
@@ -2,7 +2,7 @@ import { apiClient } from '@/apis/client';
 import type { DailyStudyResponse } from '@/types/review';
 
 export const getDailyStudy = async (date: string): Promise<DailyStudyResponse> => {
-  const response = await apiClient.get<DailyStudyResponse>('/api/v1/review', {
+  const response = await apiClient.get<DailyStudyResponse>('/api/v1/review/daily', {
     params: { date },
   });
   return response.data;

--- a/src/apis/review/queries/monthlyStudy.ts
+++ b/src/apis/review/queries/monthlyStudy.ts
@@ -2,7 +2,7 @@ import { apiClient } from '@/apis/client';
 import type { MonthlyStudyResponse } from '@/types/review';
 
 export const getMonthlyStudy = async (month: string): Promise<MonthlyStudyResponse> => {
-  const response = await apiClient.get<MonthlyStudyResponse>('/api/v1/review', {
+  const response = await apiClient.get<MonthlyStudyResponse>('/api/v1/review/monthly', {
     params: { month },
   });
   return response.data;

--- a/src/components/home/Welcome.tsx
+++ b/src/components/home/Welcome.tsx
@@ -1,11 +1,12 @@
-import { homeWelcomeMockData } from '@/mock/home/homeWelcome.mock';
 import { useProfileQuery } from '@/hooks/profile/queries/useProfileQuery';
+import { useStreakDaysQuery } from '@/hooks/profile/queries/useStreakDaysQuery';
 
 export default function HomeWelcome() {
   const { data: profileData } = useProfileQuery();
-  const { streakDays } = homeWelcomeMockData;
+  const { data: streakData } = useStreakDaysQuery();
 
   const userName = profileData?.result.user.nickname || '사용자';
+  const streakDays = streakData?.result.streakDays || 0;
 
   return (
     <div className="flex items-center justify-between rounded-2xl bg-white px-3 py-2 shadow-lg">

--- a/src/components/review/ScoreModal.tsx
+++ b/src/components/review/ScoreModal.tsx
@@ -3,10 +3,11 @@ import { useNavigate } from 'react-router-dom';
 interface ScoreModalProps {
   isOpen: boolean;
   score: number;
+  feedback?: string;
   onClose: () => void;
 }
 
-export default function ScoreModal({ isOpen, score, onClose }: ScoreModalProps) {
+export default function ScoreModal({ isOpen, score, feedback, onClose }: ScoreModalProps) {
   const navigate = useNavigate();
 
   if (!isOpen) return null;
@@ -16,16 +17,20 @@ export default function ScoreModal({ isOpen, score, onClose }: ScoreModalProps) 
     navigate('/review');
   };
 
+  const getDisplayMessage = () => {
+    if (!feedback) return '더 노력하면 발음이 훨씬 좋아질 거에요.';
+
+    // feedback의 첫 번째 문장 추출
+    const firstSentence = feedback.split('.')[0] + '.';
+    return `${firstSentence} 더 노력하면 발음이 훨씬 좋아질 거에요.`;
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="flex w-[296px] flex-col items-center gap-8 rounded-2xl bg-white p-6">
         <div className="flex flex-col items-center gap-2 text-center">
           <h2 className="text-heading-01 text-gray-100">점수는 {score}점입니다!</h2>
-          <p className="text-body-01-regular text-gray-60">
-            정말 잘하셨습니다! 더 노력하면
-            <br />
-            발음이 훨씬 좋아질 거에요.
-          </p>
+          <p className="text-body-01-regular text-gray-60">{getDisplayMessage()}</p>
         </div>
 
         <button

--- a/src/hooks/profile/queries/useStreakDaysQuery.ts
+++ b/src/hooks/profile/queries/useStreakDaysQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { profileAPI } from '@/apis/profile';
+
+export const useStreakDaysQuery = () => {
+  return useQuery({
+    queryKey: ['streakDays'],
+    queryFn: profileAPI.getStreakDays,
+  });
+};

--- a/src/hooks/review/useCalendar.ts
+++ b/src/hooks/review/useCalendar.ts
@@ -107,8 +107,10 @@ export const useCalendar = () => {
   // 학습 기록이 있는지 확인 (월별 API의 days 배열 확인)
   const hasKits = (date: Date): boolean => {
     if (!monthlyData?.result?.days) return false;
-    const dateString = formatToYearMonthDay(date);
-    return monthlyData.result.days.includes(dateString);
+
+    // API가 숫자 배열(일자만)을 반환하므로 date.getDate()와 비교
+    const dayNumber = date.getDate();
+    return monthlyData.result.days.includes(dayNumber);
   };
 
   // 오늘 날짜인지 확인

--- a/src/mock/home/homeWelcome.mock.ts
+++ b/src/mock/home/homeWelcome.mock.ts
@@ -1,9 +1,0 @@
-export interface HomeWelcomeMock {
-  userName: string;
-  streakDays: number;
-}
-
-export const homeWelcomeMockData: HomeWelcomeMock = {
-  userName: '다현',
-  streakDays: 12,
-};

--- a/src/pages/profile/WordListPage.tsx
+++ b/src/pages/profile/WordListPage.tsx
@@ -34,7 +34,7 @@ const WordListPage = () => {
       {/* 메인 컨텐츠 */}
       <main className="relative flex-1 overflow-y-auto pt-3 pb-4 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {/* 흰색 박스 */}
-        <div className="bg-white pt-16 pb-4">
+        <div className="min-h-full bg-white pt-16 pb-4">
           {/* 총 학습 횟수 */}
           <div className="absolute top-[29px] right-[16px]">
             <p className="text-body-01-semibold text-gray-100">

--- a/src/pages/review/calendar/ReviewCalendar.tsx
+++ b/src/pages/review/calendar/ReviewCalendar.tsx
@@ -4,8 +4,6 @@ import LeftIcon from '@/assets/svgs/review/review-leftarrow.svg';
 import RightIcon from '@/assets/svgs/review/review-rightarrow.svg';
 import RestudyIcon from '@/assets/svgs/review/review-restudy.svg';
 import AudioIcon from '@/assets/svgs/review/review-audio.svg';
-import StudyDayIcon from '@/assets/svgs/review/review-studyday.svg';
-import SelectDayIcon from '@/assets/svgs/review/review-selectday.svg';
 import TodayIcon from '@/assets/svgs/review/review-todayicon.svg';
 import { useCalendar } from '@/hooks/review/useCalendar';
 import { getKitRoute } from '@/utils/review/kitRouteUtils';
@@ -71,7 +69,7 @@ const ReviewCalendar = () => {
           </div>
 
           {/* 날짜 그리드 - 56x56 타일 */}
-          <div className="grid grid-cols-7">
+          <div className="grid grid-cols-7 px-2">
             {calendarDays.map((day, index) => {
               const today = isToday(day.fullDate);
               const selected = isSelected(day.fullDate);
@@ -119,9 +117,13 @@ const ReviewCalendar = () => {
                     </span>
                   )}
 
-                  {/* 학습한 날 점 */}
-                  {studied && selected && <SelectDayIcon className="h-2 w-2" />}
-                  {studied && !selected && !today && currentMonth && <StudyDayIcon className="h-2 w-2" />}
+                  {/* 학습한 날 점 - 현재 달의 날짜에만 표시 */}
+                  {studied && currentMonth && (
+                    <div
+                      className={clsx('h-2 w-2 shrink-0 rounded-full', selected ? 'bg-white' : 'bg-blue-1')}
+                      style={{ backgroundColor: !selected ? '#4C5EFF' : undefined }}
+                    />
+                  )}
                 </button>
               );
             })}
@@ -196,5 +198,4 @@ const ReviewCalendar = () => {
     </div>
   );
 };
-
 export default ReviewCalendar;

--- a/src/pages/review/words/WordList.tsx
+++ b/src/pages/review/words/WordList.tsx
@@ -23,7 +23,7 @@ const WordListPage = () => {
       {/* 메인 컨텐츠 */}
       <main className="relative flex-1 overflow-y-auto pt-3 pb-4 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {/* 흰색 박스 */}
-        <div className="bg-white pt-16 pb-4">
+        <div className="min-h-full bg-white pt-16 pb-4">
           {/* 총 학습 횟수 */}
           <div className="absolute top-[29px] right-[16px]">
             <p className="text-body-01-semibold text-gray-100">

--- a/src/pages/review/words/WordQuiz.tsx
+++ b/src/pages/review/words/WordQuiz.tsx
@@ -46,17 +46,36 @@ const WordQuiz = () => {
     progress,
     showScoreModal,
     score,
+    feedback,
     handleStartRecording,
     setShowScoreModal,
     isLoading,
     error,
+    isUploading,
+    isEvaluating,
   } = useWordQuiz();
 
   // 404 에러 체크 (학습 기록이 없는 경우)
   const isNoDataError = error instanceof AxiosError && error.response?.status === 404;
+  const isProcessing = isUploading || isEvaluating;
+  const overlayMessage = isUploading ? '녹음 업로드 중...' : '발음 평가 중...';
+  const overlaySubMessage = isUploading ? '잠시만 기다려주세요' : '발음을 분석하고 있어요';
 
   return (
     <div className="bg-background-primary relative flex h-full flex-col">
+      {/* 로딩 오버레이 */}
+      {isProcessing && (
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/50">
+          <div className="flex flex-col items-center gap-4 rounded-2xl bg-white px-8 py-6">
+            <div className="border-t-blue-1 h-12 w-12 animate-spin rounded-full border-4 border-gray-200" />
+            <div className="flex flex-col items-center gap-1">
+              <p className="text-heading-02-semibold text-gray-100">{overlayMessage}</p>
+              <p className="text-body-02-regular text-gray-60">{overlaySubMessage}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* 헤더 */}
       <header className="flex h-16 items-center justify-center bg-white px-4">
         <button onClick={() => navigate('/review')} className="absolute left-4 cursor-pointer p-2">
@@ -122,28 +141,22 @@ const WordQuiz = () => {
           // 인트로: 비활성 아이콘
           <GrayAudio className="h-[88px] w-[88px]" />
         ) : isRecording ? (
-          // 녹음 중: 타이머 + 정지 아이콘
-          <div className="relative h-[88px] w-[88px]">
-            {/* 중앙 아이콘 (파란 원 + 하얀 사각형) */}
-            <div className="absolute top-1/2 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
-              <BlueCircle className="h-[88px] w-[88px]" />
-              <WhiteSquare className="absolute top-1/2 left-1/2 h-[24px] w-[24px] -translate-x-1/2 -translate-y-1/2" />
-            </div>
-            {/* CircularProgress를 최상단에 */}
-            <div className="absolute inset-0 z-20">
-              <CircularProgress progress={progress} size={88} strokeWidth={8} />
-            </div>
-          </div>
+          // 녹음 중: 타이머 + 정지 아이콘 (조음키트와 동일한 구조)
+          <button className="relative flex size-[88px] cursor-pointer items-center justify-center">
+            <CircularProgress progress={progress} />
+            <BlueCircle className="absolute size-[88px]" />
+            <WhiteSquare className="relative size-[26px]" />
+          </button>
         ) : (
           // 활성 상태: 클릭 가능한 아이콘
-          <button onClick={handleStartRecording} className="cursor-pointer">
+          <button onClick={handleStartRecording} className="cursor-pointer" disabled={isUploading || isEvaluating}>
             <BlueAudio className="h-[88px] w-[88px]" />
           </button>
         )}
       </div>
 
       {/* 점수 모달 */}
-      <ScoreModal isOpen={showScoreModal} score={score} onClose={() => setShowScoreModal(false)} />
+      <ScoreModal isOpen={showScoreModal} score={score} feedback={feedback} onClose={() => setShowScoreModal(false)} />
     </div>
   );
 };

--- a/src/pages/search/ArticulationMethodKit.tsx
+++ b/src/pages/search/ArticulationMethodKit.tsx
@@ -94,5 +94,4 @@ const ArticulationMethodKit = () => {
     </KitListLayout>
   );
 };
-
 export default ArticulationMethodKit;

--- a/src/types/profile/index.ts
+++ b/src/types/profile/index.ts
@@ -2,5 +2,6 @@ export * from './models';
 export * from './queries/getProfile.types';
 export * from './queries/getStats.types';
 export * from './queries/getDailyWords.types';
+export * from './queries/getStreakDays.types';
 export * from './mutations/updateNickname.types';
 export * from './mutations/deleteAccount.types';

--- a/src/types/profile/queries/getStreakDays.types.ts
+++ b/src/types/profile/queries/getStreakDays.types.ts
@@ -1,0 +1,8 @@
+import type { ApiResponse } from '@/types/common/api.types';
+
+export interface StreakDaysResult {
+  streakDays: number;
+  learnedToday: boolean;
+}
+
+export type GetStreakDaysResponse = ApiResponse<StreakDaysResult>;

--- a/src/types/review/index.ts
+++ b/src/types/review/index.ts
@@ -4,3 +4,4 @@ export * from './queries/situationList.types';
 export * from './queries/kitList.types';
 export * from './queries/monthlyStudy.types';
 export * from './queries/dailyStudy.types';
+export * from './mutations/evaluateWords.types';

--- a/src/types/review/mutations/evaluateWords.types.ts
+++ b/src/types/review/mutations/evaluateWords.types.ts
@@ -1,0 +1,18 @@
+import type { ApiResponse } from '@/types/common/api.types';
+import type { LipSoundIndividualResult, LipSoundOverallResult } from '@/types/search/lipsound';
+
+// Request
+export interface WordEvaluationRequestItem {
+  kitStageId: number;
+  fileKey: string;
+  targetWord: string;
+}
+
+export type WordEvaluationRequest = WordEvaluationRequestItem[];
+
+// Response (조음 키트와 동일한 구조)
+export interface WordEvaluationResponse
+  extends ApiResponse<{
+    individualResults: LipSoundIndividualResult[];
+    overallResult?: LipSoundOverallResult;
+  }> {}

--- a/src/types/review/queries/monthlyStudy.types.ts
+++ b/src/types/review/queries/monthlyStudy.types.ts
@@ -2,7 +2,7 @@ import type { ApiResponse } from '@/types/common/api.types';
 
 export interface MonthlyStudyResult {
   month: string;
-  days: string[];
+  days: number[]; // API에서 숫자 배열로 반환 (일자만)
 }
 
 export type MonthlyStudyResponse = ApiResponse<MonthlyStudyResult>;


### PR DESCRIPTION
### 💡 To Reviewers
- 점수 모달에서 멘트 살짝 커스텀
### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 일/월별 학습 조회 API 엔드포인트 수정
- 로그아웃 API 매서드 변경
- 연속 학습일 API 연결
- 랜덤 단어 복습 퀴즈 API 연결

### 🔗 관련 이슈
- #41 