### PR TITLE
[REFACTOR] 상황극 UX 개선 

### DIFF
--- a/src/components/situation/conversation/ConversationItem.tsx
+++ b/src/components/situation/conversation/ConversationItem.tsx
@@ -47,11 +47,11 @@ export const ConversationItem = ({ turn, showAnswer = true }: ConversationItemPr
               <span
                 className={clsx('text-caption-01-semibold', turn.evaluation.isSuccess ? 'text-blue-1' : 'text-red-500')}
               >
-                {turn.evaluation.isSuccess ? '✓ 잘하셨어요!' : '✗ 연습이 필요해요!'}
+                {turn.evaluation.isSuccess ? `✓ ${turn.evaluation.feedback}` : `✗ ${turn.evaluation.feedback}`}
               </span>
               <span className="text-caption-01-medium text-gray-60">점수: {turn.evaluation.score}점</span>
             </div>
-            <p className="text-caption-01-regular text-gray-60">{turn.evaluation.feedback}</p>
+            {/* <p className="text-caption-01-regular text-gray-60">{turn.evaluation.feedback}</p> */}
           </div>
         </div>
       )}

--- a/src/pages/situation/SituationConversation.tsx
+++ b/src/pages/situation/SituationConversation.tsx
@@ -33,11 +33,11 @@ export default function SituationConversation() {
   // 대화 관리
   const conversation = useSituationConversation({
     situationId: situationIdNum,
-    onSessionEnd: (finalSummary: FinalSummary) => {
-      logger.log('[PAGE] 세션 종료, 피드백 페이지로 이동', finalSummary);
-      // 피드백 페이지로 이동하면서 데이터 전달 (대화 히스토리 포함)
+    onSessionEnd: (finalSummary: FinalSummary, turns: Turn[]) => {
+      logger.log('[PAGE] 세션 종료, 피드백 페이지로 이동', { finalSummary, turnsCount: turns.length });
+      // 피드백 페이지로 이동하면서 데이터 전달 (업데이트된 대화 히스토리 포함)
       navigate(`/situation/${situationIdNum}/feedback`, {
-        state: { finalSummary, turns: conversation.turns },
+        state: { finalSummary, turns },
       });
     },
     onEvaluationFailed: (turn: Turn) => {

--- a/src/pages/situation/SituationPractice.tsx
+++ b/src/pages/situation/SituationPractice.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useSituationPractice } from '@/hooks/situation/useSituationPractice';
+import { useSituationSessionStore } from '@/stores/useSituationSessionStore';
 import { PracticeSession } from '@/components/situation/practice';
 import { AvatarVideo } from '@/components/situation/common';
 import { Toast } from '@/components/common/Toast';
@@ -29,6 +30,9 @@ export default function SituationPractice() {
 
   // 토스트
   const toast = useToast();
+
+  // Store에서 세션 복원 플래그 설정 함수 가져오기
+  const setShouldRestore = useSituationSessionStore((state) => state.setShouldRestore);
 
   const practice = useSituationPractice({
     onPracticeComplete: () => {
@@ -79,10 +83,17 @@ export default function SituationPractice() {
     setStep('practice');
   };
 
-  // 다시 시작하기 (대화 페이지로 복귀, 세션은 유지하고 대화만 리셋)
+  // 다시 시작하기 (대화 페이지로 복귀, 저장된 세션 복원)
   const handleRestart = () => {
     logger.log('[PRACTICE] 다시 시작하기 - 대화 페이지로 복귀');
-    navigate(`/situation/${situationIdNum}/conversation`);
+
+    // 세션 복원 플래그 설정
+    setShouldRestore(true);
+
+    // 대화 페이지로 이동하면서 fromPractice 플래그 전달
+    navigate(`/situation/${situationIdNum}/conversation`, {
+      state: { fromPractice: true, situationName },
+    });
   };
 
   return (

--- a/src/stores/useSituationSessionStore.ts
+++ b/src/stores/useSituationSessionStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Turn } from '@/types/situation';
+
+interface SituationSessionState {
+  sessionId: string | null;
+  situationId: number | null;
+  situationName: string | null;
+  currentTurnIndex: number;
+  turns: Turn[];
+  currentQuestion: string;
+  shouldRestoreSession: boolean;
+}
+
+interface SituationSessionActions {
+  saveSession: (data: {
+    sessionId: string;
+    situationId: number;
+    situationName: string;
+    currentTurnIndex: number;
+    turns: Turn[];
+    currentQuestion: string;
+  }) => void;
+  clearSession: () => void;
+  setShouldRestore: (shouldRestore: boolean) => void;
+}
+
+type SituationSessionStore = SituationSessionState & SituationSessionActions;
+
+export const useSituationSessionStore = create<SituationSessionStore>()(
+  persist(
+    (set) => ({
+      // State
+      sessionId: null,
+      situationId: null,
+      situationName: null,
+      currentTurnIndex: 0,
+      turns: [],
+      currentQuestion: '',
+      shouldRestoreSession: false,
+
+      // Actions
+      saveSession: (data) =>
+        set({
+          sessionId: data.sessionId,
+          situationId: data.situationId,
+          situationName: data.situationName,
+          currentTurnIndex: data.currentTurnIndex,
+          turns: data.turns,
+          currentQuestion: data.currentQuestion,
+          shouldRestoreSession: false,
+        }),
+
+      clearSession: () =>
+        set({
+          sessionId: null,
+          situationId: null,
+          situationName: null,
+          currentTurnIndex: 0,
+          turns: [],
+          currentQuestion: '',
+          shouldRestoreSession: false,
+        }),
+
+      setShouldRestore: (shouldRestore) =>
+        set({
+          shouldRestoreSession: shouldRestore,
+        }),
+    }),
+    {
+      name: 'situation-session-storage',
+    },
+  ),
+);

--- a/src/types/situation/models.ts
+++ b/src/types/situation/models.ts
@@ -18,6 +18,7 @@ export interface Turn {
   answer?: string;
   audioFileKey?: string;
   evaluation?: Evaluation;
+  nextQuestion?: string; // 평가 실패 시 다음에 재시도할 질문
 }
 
 // 최종 요약

--- a/src/types/situation/mutations/reply.types.ts
+++ b/src/types/situation/mutations/reply.types.ts
@@ -3,6 +3,7 @@ import type { Evaluation, FinalSummary } from '../models';
 // 답변 평가 요청
 export interface ReplyRequest {
   sessionId: string;
+  turnIndex: number;
   answer: string;
   audioFileKey: string;
 }
@@ -21,4 +22,3 @@ export interface ReplyResponse {
     finalSummary: FinalSummary | null;
   };
 }
-


### PR DESCRIPTION
### 🔥 작업 내용
- 상황극에서 대답 실패 처리 -> 다시하기 클릭 시 -> 진행 상황에서 그대로 계속 가능하도록 변경
- 상황극에서 대답 실패 처리 -> 학습하기 클릭 -> 3회 문장 연습 -> 상황극 복귀 시, 진행 상황 그대로 유지되도록 변경
- 진행 상황은 localStorage에 저장. 1. 뒤로가기 2. 종료하기 3. 다른 상황극 진입 시, 자동으로 삭제 처리

### 🔗 관련 이슈
- #42 
