### PR TITLE
[FIX] 조음키트 수정 Presigned URL 저장 폴더 위치 통일화 및 버그 수정

### DIFF
--- a/src/constants/search/articulationPractice.ts
+++ b/src/constants/search/articulationPractice.ts
@@ -18,48 +18,48 @@ export type ArticulationType =
 
 // 통합 단어 데이터
 export const articulationPracticeWords: Record<ArticulationType, PracticeWord[]> = {
-  // 조음 위치별 (1-12)
+  // 조음 위치별 - 백엔드 "실전 발음 연습" stage ID 사용
   'lip-sound': [
-    { round: 1, word: '마음', category: '명사', kitStageId: 1 },
-    { round: 2, word: '바다', category: '명사', kitStageId: 2 },
-    { round: 3, word: '포도', category: '명사', kitStageId: 3 },
+    { round: 1, word: '마음', category: '명사', kitStageId: 8 },
+    { round: 2, word: '바다', category: '명사', kitStageId: 8 },
+    { round: 3, word: '포도', category: '명사', kitStageId: 8 },
   ],
   'tongue-tip': [
-    { round: 1, word: '나비', category: '명사', kitStageId: 4 },
-    { round: 2, word: '다리', category: '명사', kitStageId: 5 },
-    { round: 3, word: '라면', category: '명사', kitStageId: 6 },
+    { round: 1, word: '나비', category: '명사', kitStageId: 10 },
+    { round: 2, word: '다리', category: '명사', kitStageId: 10 },
+    { round: 3, word: '라면', category: '명사', kitStageId: 10 },
   ],
   throat: [
-    { round: 1, word: '호수', category: '명사', kitStageId: 7 },
-    { round: 2, word: '강', category: '명사', kitStageId: 8 },
-    { round: 3, word: '커피', category: '명사', kitStageId: 9 },
+    { round: 1, word: '호수', category: '명사', kitStageId: 12 },
+    { round: 2, word: '강', category: '명사', kitStageId: 12 },
+    { round: 3, word: '커피', category: '명사', kitStageId: 12 },
   ],
   gum: [
-    { round: 1, word: '나무', category: '명사', kitStageId: 10 },
-    { round: 2, word: '도시', category: '명사', kitStageId: 11 },
-    { round: 3, word: '리본', category: '명사', kitStageId: 12 },
+    { round: 1, word: '나무', category: '명사', kitStageId: 14 },
+    { round: 2, word: '도시', category: '명사', kitStageId: 14 },
+    { round: 3, word: '리본', category: '명사', kitStageId: 14 },
   ],
 
-  // 조음 방법별 (13-24)
+  // 조음 방법별 - 백엔드 "실전 발음 연습" stage ID 사용
   plosive: [
-    { round: 1, word: '고기', category: '명사', kitStageId: 13 },
-    { round: 2, word: '가방', category: '명사', kitStageId: 14 },
-    { round: 3, word: '토끼', category: '명사', kitStageId: 15 },
+    { round: 1, word: '고기', category: '명사', kitStageId: 16 },
+    { round: 2, word: '가방', category: '명사', kitStageId: 16 },
+    { round: 3, word: '토끼', category: '명사', kitStageId: 16 },
   ],
   fricative: [
-    { round: 1, word: '사자', category: '명사', kitStageId: 16 },
-    { round: 2, word: '수박', category: '명사', kitStageId: 17 },
+    { round: 1, word: '사자', category: '명사', kitStageId: 18 },
+    { round: 2, word: '수박', category: '명사', kitStageId: 18 },
     { round: 3, word: '산책', category: '명사', kitStageId: 18 },
   ],
   'liquid-nasal': [
-    { round: 1, word: '음식', category: '명사', kitStageId: 19 },
+    { round: 1, word: '음식', category: '명사', kitStageId: 20 },
     { round: 2, word: '모자', category: '명사', kitStageId: 20 },
-    { round: 3, word: '노래', category: '명사', kitStageId: 21 },
+    { round: 3, word: '노래', category: '명사', kitStageId: 20 },
   ],
   'jaw-movement': [
     { round: 1, word: '아기', category: '명사', kitStageId: 22 },
-    { round: 2, word: '운동', category: '명사', kitStageId: 23 },
-    { round: 3, word: '우산', category: '명사', kitStageId: 24 },
+    { round: 2, word: '운동', category: '명사', kitStageId: 22 },
+    { round: 3, word: '우산', category: '명사', kitStageId: 22 },
   ],
 };
 

--- a/src/constants/talkingkit/soundPosition/articulationPractice.ts
+++ b/src/constants/talkingkit/soundPosition/articulationPractice.ts
@@ -18,48 +18,48 @@ export type ArticulationType =
 
 // 통합 단어 데이터
 export const articulationPracticeWords: Record<ArticulationType, PracticeWord[]> = {
-  // 조음 위치별 (1-12)
+  // 조음 위치별 - 백엔드 "실전 발음 연습" stage ID 사용
   'lip-sound': [
-    { round: 1, word: '마음', category: '명사', kitStageId: 1 },
-    { round: 2, word: '바다', category: '명사', kitStageId: 2 },
-    { round: 3, word: '포도', category: '명사', kitStageId: 3 },
+    { round: 1, word: '마음', category: '명사', kitStageId: 8 },
+    { round: 2, word: '바다', category: '명사', kitStageId: 8 },
+    { round: 3, word: '포도', category: '명사', kitStageId: 8 },
   ],
   'tongue-tip': [
-    { round: 1, word: '나비', category: '명사', kitStageId: 4 },
-    { round: 2, word: '다리', category: '명사', kitStageId: 5 },
-    { round: 3, word: '라면', category: '명사', kitStageId: 6 },
+    { round: 1, word: '나비', category: '명사', kitStageId: 10 },
+    { round: 2, word: '다리', category: '명사', kitStageId: 10 },
+    { round: 3, word: '라면', category: '명사', kitStageId: 10 },
   ],
   throat: [
-    { round: 1, word: '호수', category: '명사', kitStageId: 7 },
-    { round: 2, word: '강', category: '명사', kitStageId: 8 },
-    { round: 3, word: '커피', category: '명사', kitStageId: 9 },
+    { round: 1, word: '호수', category: '명사', kitStageId: 12 },
+    { round: 2, word: '강', category: '명사', kitStageId: 12 },
+    { round: 3, word: '커피', category: '명사', kitStageId: 12 },
   ],
   gum: [
-    { round: 1, word: '나무', category: '명사', kitStageId: 10 },
-    { round: 2, word: '도시', category: '명사', kitStageId: 11 },
-    { round: 3, word: '리본', category: '명사', kitStageId: 12 },
+    { round: 1, word: '나무', category: '명사', kitStageId: 14 },
+    { round: 2, word: '도시', category: '명사', kitStageId: 14 },
+    { round: 3, word: '리본', category: '명사', kitStageId: 14 },
   ],
 
-  // 조음 방법별 (13-24)
+  // 조음 방법별 - 백엔드 "실전 발음 연습" stage ID 사용
   plosive: [
-    { round: 1, word: '고기', category: '명사', kitStageId: 13 },
-    { round: 2, word: '가방', category: '명사', kitStageId: 14 },
-    { round: 3, word: '토끼', category: '명사', kitStageId: 15 },
+    { round: 1, word: '고기', category: '명사', kitStageId: 16 },
+    { round: 2, word: '가방', category: '명사', kitStageId: 16 },
+    { round: 3, word: '토끼', category: '명사', kitStageId: 16 },
   ],
   fricative: [
-    { round: 1, word: '사자', category: '명사', kitStageId: 16 },
-    { round: 2, word: '수박', category: '명사', kitStageId: 17 },
+    { round: 1, word: '사자', category: '명사', kitStageId: 18 },
+    { round: 2, word: '수박', category: '명사', kitStageId: 18 },
     { round: 3, word: '산책', category: '명사', kitStageId: 18 },
   ],
   'liquid-nasal': [
-    { round: 1, word: '음식', category: '명사', kitStageId: 19 },
+    { round: 1, word: '음식', category: '명사', kitStageId: 20 },
     { round: 2, word: '모자', category: '명사', kitStageId: 20 },
-    { round: 3, word: '노래', category: '명사', kitStageId: 21 },
+    { round: 3, word: '노래', category: '명사', kitStageId: 20 },
   ],
   'jaw-movement': [
     { round: 1, word: '아기', category: '명사', kitStageId: 22 },
-    { round: 2, word: '운동', category: '명사', kitStageId: 23 },
-    { round: 3, word: '우산', category: '명사', kitStageId: 24 },
+    { round: 2, word: '운동', category: '명사', kitStageId: 22 },
+    { round: 3, word: '우산', category: '명사', kitStageId: 22 },
   ],
 };
 

--- a/src/pages/auth/loginForm/LoginForm.tsx
+++ b/src/pages/auth/loginForm/LoginForm.tsx
@@ -56,7 +56,7 @@ const LoginForm = () => {
             value={password}
             onChange={handlePasswordChange}
             error={passwordError}
-            placeholder="6자리를 입력하세요"
+            placeholder="8자리 이상 입력하세요"
           />
         </div>
 

--- a/src/pages/review/calendar/ReviewCalendar.tsx
+++ b/src/pages/review/calendar/ReviewCalendar.tsx
@@ -162,7 +162,12 @@ const ReviewCalendar = () => {
                   };
 
                   const handleListen = () => {
-                    navigate(`/review/practice/listen?recordingId=${item.recordingId}`);
+                    if (item.type === 'situation') {
+                      navigate(`/review/practice/listen?recordingId=${item.recordingId}`);
+                    } else {
+                      // kit 타입 - 조음 키트
+                      navigate(`/review/practice/articulation-listen?kitId=${item.id}`);
+                    }
                   };
 
                   return (

--- a/src/pages/review/practice/listen/ArticulationListen.tsx
+++ b/src/pages/review/practice/listen/ArticulationListen.tsx
@@ -70,7 +70,7 @@ const ArticulationListen = () => {
     );
   }
 
-  const { kitName, records } = data.result;
+  const { kitName, records = [] } = data.result || {};
 
   // 평균 점수 계산
   const averageScore =

--- a/src/pages/talkingkit/articulation/ArticulationStep1.tsx
+++ b/src/pages/talkingkit/articulation/ArticulationStep1.tsx
@@ -50,7 +50,7 @@ const ArticulationStep1 = () => {
   };
 
   const handleBackClick = () => {
-    navigate(-1);
+    navigate('/search');
   };
 
   return (

--- a/src/pages/talkingkit/longSoundKit/breathing/BreathingExercise.tsx
+++ b/src/pages/talkingkit/longSoundKit/breathing/BreathingExercise.tsx
@@ -73,7 +73,7 @@ const BreathingExercise = () => {
         <Step1Layout
           headerTitle={`${kit.highlightedText} 소리내기`}
           title={stage1Name}
-          onBackClick={() => navigate(-1)}
+          onBackClick={() => navigate('/talkingkit')}
         >
           <div className="flex h-[352px] w-full items-center justify-center">
             <h1 className="text-[48px] leading-normal font-medium text-[#ff1f1f]">GREAT!</h1>

--- a/src/pages/talkingkit/longSoundKit/vowelPitch/VowelPitchResult.tsx
+++ b/src/pages/talkingkit/longSoundKit/vowelPitch/VowelPitchResult.tsx
@@ -50,7 +50,7 @@ const VowelPitchResult = () => {
         // 4. 학습 기록 저장 API 호출
         logger.log('학습 기록 저장 중...');
         await kitAPI.saveKitStageLog({
-          kitStageId: 3,
+          kitStageId: 2, // 모음 길게 소리내기 (길게 소리내기 키트의 2번째 stage)
           evaluationScore: evaluationResult.score,
           evaluationFeedback: evaluationResult.feedback,
           isSuccess: true,

--- a/src/pages/talkingkit/loudSoundKit/loudSound/LoudSound.tsx
+++ b/src/pages/talkingkit/loudSoundKit/loudSound/LoudSound.tsx
@@ -29,7 +29,7 @@ const LoudSound = () => {
   };
 
   const handleBack = () => {
-    navigate(-1);
+    navigate('/talkingkit');
   };
 
   const handleNext = () => {

--- a/src/pages/talkingkit/soundPosition/lipSound/Step1.tsx
+++ b/src/pages/talkingkit/soundPosition/lipSound/Step1.tsx
@@ -3,7 +3,10 @@ import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import LeftArrowIcon from '@/assets/svgs/talkingkit/common/leftarrow.svg';
 import AnimatedContainer from '@/components/talkingkit/common/AnimatedContainer';
 import TimerProgressBar from '@/components/talkingkit/progressBar/TimerProgressBar';
-import { articulationTypeConfig, type ArticulationType } from '@/constants/talkingkit/soundPosition/articulationPractice';
+import {
+  articulationTypeConfig,
+  type ArticulationType,
+} from '@/constants/talkingkit/soundPosition/articulationPractice';
 
 const ArticulationStep1 = () => {
   const navigate = useNavigate();
@@ -21,9 +24,7 @@ const ArticulationStep1 = () => {
   const config = articulationTypeConfig[validType];
 
   // URL 패턴에서 기본 경로 추출
-  const basePath = location.pathname.includes('sound-position')
-    ? 'sound-position'
-    : 'sound-way';
+  const basePath = location.pathname.includes('sound-position') ? 'sound-position' : 'sound-way';
 
   // 시작하기 버튼 클릭
   const handleButtonClick = () => {
@@ -50,7 +51,11 @@ const ArticulationStep1 = () => {
   };
 
   const handleBackClick = () => {
-    navigate(-1);
+    if (basePath === 'sound-position') {
+      navigate('/search/articulation-position');
+    } else {
+      navigate('/search/articulation-method');
+    }
   };
 
   return (

--- a/src/pages/talkingkit/steadySoundKit/steadySound/SteadySound.tsx
+++ b/src/pages/talkingkit/steadySoundKit/steadySound/SteadySound.tsx
@@ -103,7 +103,7 @@ const SteadySound = () => {
   };
 
   const handleBack = () => {
-    navigate(-1);
+    navigate('/talkingkit');
   };
 
   const handleNext = () => {

--- a/src/utils/review/kitRouteUtils.ts
+++ b/src/utils/review/kitRouteUtils.ts
@@ -3,6 +3,41 @@
  */
 export const getKitRoute = (kitName: string): string => {
   const kitNameLower = kitName.toLowerCase();
+  const kitNameNoSpace = kitName.replace(/\s/g, '');
+
+  // 조음 위치 키트
+  if (kitNameLower.includes('입술') || kitNameNoSpace.includes('입술소리')) {
+    return '/talkingkit/sound-position/lip-sound/step1';
+  }
+
+  if (kitNameLower.includes('혀끝') || kitNameNoSpace.includes('혀끝소리')) {
+    return '/talkingkit/sound-position/tongue-tip/step1';
+  }
+
+  if (kitNameLower.includes('목구멍') || kitNameNoSpace.includes('목구멍소리')) {
+    return '/talkingkit/sound-position/throat/step1';
+  }
+
+  if (kitNameLower.includes('잇몸') || kitNameNoSpace.includes('잇몸소리')) {
+    return '/talkingkit/sound-position/gum/step1';
+  }
+
+  // 조음 방법 키트
+  if (kitNameLower.includes('파열음')) {
+    return '/talkingkit/sound-way/plosive/step1';
+  }
+
+  if (kitNameLower.includes('마찰음')) {
+    return '/talkingkit/sound-way/fricative/step1';
+  }
+
+  if (kitNameLower.includes('유음') || kitNameLower.includes('비음')) {
+    return '/talkingkit/sound-way/liquid-nasal/step1';
+  }
+
+  if (kitNameLower.includes('턱') || kitNameLower.includes('턱 움직임')) {
+    return '/talkingkit/sound-way/jaw-movement/step1';
+  }
 
   // 호흡 관련 키트
   if (kitNameLower.includes('길게') || kitNameLower.includes('호흡')) {


### PR DESCRIPTION
### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- **현재 호흡 및 발성 키트에서 길게 소리내기 제외하고는 전부 녹음X -> 복습에 안뜨게 해둠.(일단)**
- **복습 페이지 (캘린더 포함)에서 재학습 클릭시 경로 오류 수정** -> 재확인 필요
- 조음 키트 복습 및 상황극 복습 대부분 정상 작동 중
- 로그인 PLACEHOLDER 6자리 -> 8자리 변경

### 🤔 추후 작업 예정
- 조음키트 복습페이지에서 점수 뜨는 부분이 단어 한개 평가 결과로 출력되고 있음 -> 수정
- 북마크 클릭 시, 애니메이션 효과 (지금 너무 정적임)
- 조음키트, 상황극 학습 후 복습 페이지로 가면 바로 확인가능하도록 캐시 전략 수정

### 🔗 관련 이슈
- #50 
