### PR TITLE
[FIX] Review FIX

### DIFF
--- a/src/components/common/AnimatedBookmark.tsx
+++ b/src/components/common/AnimatedBookmark.tsx
@@ -1,0 +1,25 @@
+import { motion } from 'framer-motion';
+import BookmarkCheckedIcon from '@/assets/svgs/home/bookmarkchecked.svg';
+import BookmarkEmptyIcon from '@/assets/svgs/talkingkit/common/bookmarkempty.svg';
+
+interface AnimatedBookmarkProps {
+  isBookmarked: boolean;
+  className?: string;
+}
+
+export const AnimatedBookmark = ({ isBookmarked, className = 'h-full w-full' }: AnimatedBookmarkProps) => {
+  return (
+    <motion.div
+      whileTap={{ scale: [1, 1.3, 1] }}
+      transition={{ duration: 0.3, ease: 'easeInOut' }}
+      className={className}
+    >
+      {isBookmarked ? (
+        <BookmarkCheckedIcon className="h-full w-full" />
+      ) : (
+        <BookmarkEmptyIcon className="h-full w-full" />
+      )}
+    </motion.div>
+  );
+};
+

--- a/src/components/studytalk/PracticeKitCard.tsx
+++ b/src/components/studytalk/PracticeKitCard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { useRemoveBookmarkMutation } from '@/hooks/bookmark/mutations/useRemoveBookmarkMutation';
-import BookmarkIcon from '@/assets/svgs/home/bookmarkchecked.svg';
+import { AnimatedBookmark } from '@/components/common/AnimatedBookmark';
 import DeleteConfirmModal from '@/components/common/DeleteConfirmModal';
 
 interface PracticeKitCardProps {
@@ -50,7 +50,7 @@ export default function PracticeKitCard({ bookmarkId, kitId, category, title, on
           className="flex size-[48px] shrink-0 cursor-pointer items-center justify-center"
           aria-label="북마크 제거"
         >
-          <BookmarkIcon className="h-[21.814px] w-[16px] cursor-pointer" />
+          <AnimatedBookmark isBookmarked={true} className="h-[21.814px] w-[16px]" />
         </button>
 
         <div className="flex w-full flex-col items-start px-[4px]">

--- a/src/components/studytalk/SituationPracticeCard.tsx
+++ b/src/components/studytalk/SituationPracticeCard.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { useRemoveBookmarkMutation } from '@/hooks/bookmark/mutations/useRemoveBookmarkMutation';
 import { getSituationCategoryQuery } from '@/utils/studytalk/categoryUtils';
-import BookmarkIcon from '@/assets/svgs/home/bookmarkchecked.svg';
+import { AnimatedBookmark } from '@/components/common/AnimatedBookmark';
 import DeleteConfirmModal from '@/components/common/DeleteConfirmModal';
 
 interface SituationPracticeCardProps {
@@ -52,7 +52,7 @@ export default function SituationPracticeCard({
           className="flex size-[48px] shrink-0 cursor-pointer items-center justify-center"
           aria-label="북마크 제거"
         >
-          <BookmarkIcon className="h-[21.814px] w-[16px] cursor-pointer" />
+          <AnimatedBookmark isBookmarked={true} className="h-[21.814px] w-[16px]" />
         </button>
 
         <div className="flex w-full flex-col items-start px-[4px]">

--- a/src/components/talkingkit/common/KitCard.tsx
+++ b/src/components/talkingkit/common/KitCard.tsx
@@ -3,8 +3,7 @@ import type { Kit } from '@/types/talkingkit';
 import type { TalkingKit } from '@/types/talkingkit';
 import { useAddKitBookmarkMutation } from '@/hooks/bookmark/mutations/useAddKitBookmarkMutation';
 import { useRemoveBookmarkMutation } from '@/hooks/bookmark/mutations/useRemoveBookmarkMutation';
-import BookmarkEmptyIcon from '@/assets/svgs/talkingkit/common/bookmarkempty.svg';
-import BookmarkCheckedIcon from '@/assets/svgs/home/bookmarkchecked.svg';
+import { AnimatedBookmark } from '@/components/common/AnimatedBookmark';
 
 interface KitCardProps {
   kit: TalkingKit | Kit;
@@ -73,11 +72,7 @@ const KitCard = ({ kit, onClick, isBookmarked = false, bookmarkId }: KitCardProp
           aria-label={isBookmarked ? '북마크 제거' : '북마크 추가'}
         >
           <div className="absolute inset-[24.81%_33.33%_29.75%_33.33%]">
-            {isBookmarked ? (
-              <BookmarkCheckedIcon className="h-full w-full" />
-            ) : (
-              <BookmarkEmptyIcon className="h-full w-full" />
-            )}
+            <AnimatedBookmark isBookmarked={isBookmarked} />
           </div>
         </button>
 

--- a/src/components/talkingkit/common/SituationCard.tsx
+++ b/src/components/talkingkit/common/SituationCard.tsx
@@ -2,8 +2,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import type { Situation } from '@/types/search';
 import { useAddSituationBookmarkMutation } from '@/hooks/bookmark/mutations/useAddSituationBookmarkMutation';
 import { useRemoveBookmarkMutation } from '@/hooks/bookmark/mutations/useRemoveBookmarkMutation';
-import BookmarkEmptyIcon from '@/assets/svgs/talkingkit/common/bookmarkempty.svg';
-import BookmarkCheckedIcon from '@/assets/svgs/home/bookmarkchecked.svg';
+import { AnimatedBookmark } from '@/components/common/AnimatedBookmark';
 
 interface SituationCardProps {
   situation: Situation;
@@ -52,11 +51,7 @@ const SituationCard = ({ situation, onClick, isBookmarked = false, bookmarkId }:
           aria-label={isBookmarked ? '북마크 제거' : '북마크 추가'}
         >
           <div className="absolute inset-[24.81%_33.33%_29.75%_33.33%]">
-            {isBookmarked ? (
-              <BookmarkCheckedIcon className="h-full w-full" />
-            ) : (
-              <BookmarkEmptyIcon className="h-full w-full" />
-            )}
+            <AnimatedBookmark isBookmarked={isBookmarked} />
           </div>
         </button>
 

--- a/src/hooks/review/queries/useDailyStudyQuery.ts
+++ b/src/hooks/review/queries/useDailyStudyQuery.ts
@@ -1,10 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 import { reviewAPI } from '@/apis/review';
 
+/**
+ * 특정 날짜의 일별 학습 기록 조회
+ * 학습 완료 후 즉시 반영을 위해 mount 시 항상 refetch
+ */
 export const useDailyStudyQuery = (date: string | null) => {
   return useQuery({
     queryKey: ['dailyStudy', date],
     queryFn: () => reviewAPI.getDailyStudy(date!),
     enabled: !!date,
+    refetchOnMount: 'always',
   });
 };

--- a/src/hooks/review/queries/useMonthlyStudyQuery.ts
+++ b/src/hooks/review/queries/useMonthlyStudyQuery.ts
@@ -1,9 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { reviewAPI } from '@/apis/review';
 
+/**
+ * 월별 학습 기록 조회 (학습한 날짜 목록)
+ * 학습 완료 후 즉시 반영을 위해 mount 시 항상 refetch
+ */
 export const useMonthlyStudyQuery = (month: string) => {
   return useQuery({
     queryKey: ['monthlyStudy', month],
     queryFn: () => reviewAPI.getMonthlyStudy(month),
+    refetchOnMount: 'always',
   });
 };

--- a/src/hooks/review/useKitReviewList.ts
+++ b/src/hooks/review/useKitReviewList.ts
@@ -3,7 +3,6 @@ import { useInfiniteKitListQuery } from './queries/useInfiniteKitListQuery';
 import { filterKitsByCategory } from '@/utils/review';
 import { sortMap } from '@/constants/review/sort';
 import { useReviewStore } from '@/stores/useReviewStore';
-import type { KitCategoryOption, SortOption } from '@/constants/review/sort';
 
 export const useKitReviewList = () => {
   // Zustand 스토어에서 상태와 액션 가져오기

--- a/src/hooks/review/useKitReviewList.ts
+++ b/src/hooks/review/useKitReviewList.ts
@@ -1,12 +1,16 @@
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useInfiniteKitListQuery } from './queries/useInfiniteKitListQuery';
 import { filterKitsByCategory } from '@/utils/review';
 import { sortMap } from '@/constants/review/sort';
+import { useReviewStore } from '@/stores/useReviewStore';
 import type { KitCategoryOption, SortOption } from '@/constants/review/sort';
 
 export const useKitReviewList = () => {
-  const [selectedCategory, setSelectedCategory] = useState<KitCategoryOption>('전체');
-  const [selectedSort, setSelectedSort] = useState<SortOption>('최신순');
+  // Zustand 스토어에서 상태와 액션 가져오기
+  const selectedCategory = useReviewStore((state) => state.kitCategory);
+  const selectedSort = useReviewStore((state) => state.kitSort);
+  const setSelectedCategory = useReviewStore((state) => state.setKitCategory);
+  const setSelectedSort = useReviewStore((state) => state.setKitSort);
 
   const apiSort = sortMap[selectedSort];
 

--- a/src/hooks/review/useSituationReviewList.ts
+++ b/src/hooks/review/useSituationReviewList.ts
@@ -1,5 +1,6 @@
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useInfiniteSituationListQuery } from './queries/useInfiniteSituationListQuery';
+import { useReviewStore } from '@/stores/useReviewStore';
 import type { SituationCategoryOption } from '@/components/studytalk/SituationCategoryFilter';
 
 type SortOption = '최신순' | '오래된순';
@@ -26,8 +27,11 @@ const sortMap: Record<SortOption, 'latest' | 'oldest'> = {
 };
 
 export const useSituationReviewList = () => {
-  const [selectedCategory, setSelectedCategory] = useState<SituationCategoryOption>('전체');
-  const [selectedSort, setSelectedSort] = useState<SortOption>('최신순');
+  // Zustand 스토어에서 상태와 액션 가져오기
+  const selectedCategory = useReviewStore((state) => state.situationCategory);
+  const selectedSort = useReviewStore((state) => state.situationSort);
+  const setSelectedCategory = useReviewStore((state) => state.setSituationCategory);
+  const setSelectedSort = useReviewStore((state) => state.setSituationSort);
 
   const apiCategory = categoryMap[selectedCategory];
   const apiSort = sortMap[selectedSort];

--- a/src/pages/freetalk/FreeTalk.tsx
+++ b/src/pages/freetalk/FreeTalk.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ChevronLeft from '@/assets/svgs/home/leftarrow.svg';
 import Mike1 from '@/assets/svgs/home/mike1.svg';
@@ -9,12 +9,16 @@ import { useTypingAnimation } from '@/hooks/freetalk/useTypingAnimation';
 import { useFreeTalkConversation } from '@/hooks/freetalk/useFreeTalkConversation';
 import { useChromaKey } from '@/hooks/freetalk/useChromaKey';
 import { logger } from '@/utils/common/loggerUtils';
+import Modal, { ModalButton } from '@/components/common/Modal';
 import clsx from 'clsx';
 
 export default function FreeTalk() {
   const navigate = useNavigate();
   const scrollRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  // 안내 모달 상태
+  const [isGuideModalOpen, setIsGuideModalOpen] = useState(true);
 
   // 대화 관리 훅 (아바타 포함)
   const conversation = useFreeTalkConversation();
@@ -144,8 +148,8 @@ export default function FreeTalk() {
                 key={num}
                 className={clsx(
                   'flex h-[30px] items-center justify-center rounded-[8px] text-[16px] leading-normal font-normal shadow-lg',
-                  status === 'completed' && 'text-gray-40 w-[70px] bg-[#757a9e]',
-                  isActive && 'w-[70px] border border-solid border-[#757a9e] bg-white text-[#757a9e]',
+                  status === 'completed' && 'text-gray-40 bg-blue-4 w-[70px]',
+                  isActive && 'border-blue-4 text-blue-4 w-[70px] border border-solid bg-white',
                   status === 'pending' && 'bg-gray-20 w-[70px] text-[#232323]',
                 )}
               >
@@ -178,7 +182,7 @@ export default function FreeTalk() {
                 </p>
                 <button
                   onClick={() => conversation.startSession()}
-                  className="cursor-pointer rounded-lg bg-[#757a9e] px-4 py-2 text-[14px] text-white"
+                  className="bg-blue-4 cursor-pointer rounded-lg px-4 py-2 text-[14px] text-white"
                 >
                   재시도
                 </button>
@@ -190,7 +194,7 @@ export default function FreeTalk() {
               <div className="absolute inset-0 z-20 flex items-center justify-center bg-white/90">
                 <button
                   onClick={() => conversation.startSession()}
-                  className="cursor-pointer rounded-lg bg-[#757a9e] px-4 py-2 text-[16px] text-white"
+                  className="bg-blue-4 cursor-pointer rounded-lg px-4 py-2 text-[16px] text-white"
                 >
                   아바타 시작하기
                 </button>
@@ -232,7 +236,7 @@ export default function FreeTalk() {
             <div className="mb-6 flex flex-col gap-4">
               {/* 아바타 질문 (타이핑 효과) */}
               <div className="flex justify-start">
-                <div className="flex min-h-[62px] w-[361px] items-center justify-center rounded-tl-[2px] rounded-tr-[16px] rounded-br-[16px] rounded-bl-[16px] bg-[#757a9e] px-[16px] py-[16px] shadow-lg">
+                <div className="bg-blue-4 flex min-h-[62px] w-[361px] items-center justify-center rounded-tl-[2px] rounded-tr-[16px] rounded-br-[16px] rounded-bl-[16px] px-[16px] py-[16px] shadow-lg">
                   <p className="text-center text-[20px] leading-normal font-normal wrap-break-word whitespace-pre-wrap text-white">
                     {displayedText}
                   </p>
@@ -304,6 +308,30 @@ export default function FreeTalk() {
           </button>
         )}
       </div>
+
+      {/* 안내 모달 */}
+      <Modal isOpen={isGuideModalOpen} onClose={() => setIsGuideModalOpen(false)} hideCloseOnBackdrop>
+        <div className="flex w-[280px] flex-col items-center gap-[20px]">
+          {/* 아이콘 */}
+          <div className="flex h-[56px] w-[56px] items-center justify-center rounded-full">
+            <span className="text-[40px]">⚠️</span>
+          </div>
+
+          {/* 텍스트 */}
+          <div className="flex flex-col items-center gap-[6px]">
+            <p className="text-center text-[20px] leading-normal font-semibold text-gray-100">
+              아바타가 말하는 내용을
+              <br />
+              전부 듣고 대답해주세요!
+            </p>
+          </div>
+
+          {/* 버튼 */}
+          <ModalButton onClick={() => setIsGuideModalOpen(false)} variant="primary" className="w-full!">
+            계속하기
+          </ModalButton>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/src/pages/review/calendar/ReviewCalendar.tsx
+++ b/src/pages/review/calendar/ReviewCalendar.tsx
@@ -154,7 +154,7 @@ const ReviewCalendar = () => {
                 {/* 키트 리스트 */}
                 {getKitsForDate(selectedDate).map((item: DailyStudyItem, index: number) => {
                   const handleRestudy = () => {
-                    if (item.type === 'situation') {
+                    if (item.type === 'SITUATION') {
                       navigate(getSituationRoute(item.id));
                     } else {
                       navigate(getKitRoute(item.name));
@@ -162,7 +162,7 @@ const ReviewCalendar = () => {
                   };
 
                   const handleListen = () => {
-                    if (item.type === 'situation') {
+                    if (item.type === 'SITUATION') {
                       navigate(`/review/practice/listen?recordingId=${item.recordingId}`);
                     } else {
                       // kit 타입 - 조음 키트

--- a/src/pages/review/practice/listen/ArticulationListen.tsx
+++ b/src/pages/review/practice/listen/ArticulationListen.tsx
@@ -9,6 +9,7 @@ import BlueSelect from '@/assets/svgs/review/review-blueselect.svg';
 import ProgressBar from '@/components/review/ProgressBar';
 import { useKitDetailQuery } from '@/hooks/review/queries/useKitDetailQuery';
 import { useAudioPlayer } from '@/hooks/review/useAudioPlayer';
+import { calculateAverageFeedback } from '@/utils/review';
 
 const ArticulationListen = () => {
   const navigate = useNavigate();
@@ -78,8 +79,8 @@ const ArticulationListen = () => {
       ? Math.round(records.reduce((sum, record) => sum + record.evaluationScore, 0) / records.length)
       : 0;
 
-  // 대표 피드백 (첫 번째 레코드의 피드백 사용)
-  const representativeFeedback = records.length > 0 ? records[0].evaluationFeedback : '피드백이 없습니다';
+  // 평균 피드백 계산
+  const averageFeedback = calculateAverageFeedback(records.map((record) => record.evaluationFeedback));
 
   return (
     <div className="bg-background-primary relative flex h-full flex-col">
@@ -99,13 +100,14 @@ const ArticulationListen = () => {
 
       {/* 점수 및 피드백 영역 */}
       <div className="relative bg-white px-4 pt-[14px] pb-[32px]">
+        <p className="text-body-02-regular text-gray-60 mb-1">평균 점수</p>
         <p className="text-heading-01-semibold mb-[16px] text-gray-100">{averageScore}점</p>
         <div className="relative flex gap-[10px]">
           {/* 세로선 */}
           <div className="bg-gray-20 h-auto w-px" />
           {/* 피드백 텍스트 */}
           <div className="text-body-01-regular text-gray-100">
-            <p className="whitespace-pre-wrap">{representativeFeedback}</p>
+            <p className="whitespace-pre-wrap">{averageFeedback}</p>
           </div>
         </div>
       </div>
@@ -131,6 +133,7 @@ const ArticulationListen = () => {
                 </p>
                 <p className="text-heading-02-semibold text-left text-gray-100">{record.targetWord}</p>
                 <p className="text-body-02-regular text-gray-60 text-left">{record.evaluationScore}점</p>
+                <p className="text-body-02-regular text-gray-60 text-left">{record.evaluationFeedback}</p>
               </button>
 
               {/* 파란색 화살표 */}

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -1,4 +1,4 @@
-import { useState, lazy, Suspense, useEffect } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import BottomNav from '@/components/common/BottomNav';
 import ArrowButton from '@/assets/svgs/home/arrow-button.svg';
@@ -8,15 +8,15 @@ import { useKitCategories } from '@/hooks/talkingkit/queries/useKitCategories';
 import { useSituations } from '@/hooks/search/queries/useSituations';
 import { getSituationCategoryQuery } from '@/utils/common/situationUtils';
 import { logger } from '@/utils/common/loggerUtils';
+import { useSearchStore } from '@/stores/useSearchStore';
 
 // Lazy load home icon
 const HomeIcon = lazy(() => import('@/assets/svgs/search/studyfind-home.svg'));
 
-type TabType = '조음발음' | '상황극';
-
 const Search = () => {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<TabType>('조음발음');
+  const activeTab = useSearchStore((state) => state.activeTab);
+  const setActiveTab = useSearchStore((state) => state.setActiveTab);
   const { data: kitCategoriesData, isLoading, error } = useKitCategories();
   const { data: situationsData } = useSituations('daily');
 

--- a/src/pages/studytalk/HomeStudyTalk.tsx
+++ b/src/pages/studytalk/HomeStudyTalk.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useBookmarkList } from '@/hooks/bookmark/queries/useBookmarkList';
 import type { BookmarkSortType, BookmarkItem } from '@/types/bookmark';
@@ -8,31 +8,32 @@ import {
   getKitCategoryParam,
 } from '@/utils/studytalk/categoryUtils';
 import { getKitRoute } from '@/utils/talkingkit/routingUtils';
+import { useStudyTalkStore } from '@/stores/useStudyTalkStore';
 import BottomNav from '@/components/common/BottomNav';
 import StudyTalkTabs from '@/components/studytalk/StudyTalkTabs';
 import CategoryFilter from '@/components/studytalk/CategoryFilter';
-import SituationCategoryFilter, { type SituationCategoryOption } from '@/components/studytalk/SituationCategoryFilter';
+import SituationCategoryFilter from '@/components/studytalk/SituationCategoryFilter';
 import SortFilter from '@/components/studytalk/SortFilter';
 import PracticeKitCard from '@/components/studytalk/PracticeKitCard';
 import SituationPracticeCard from '@/components/studytalk/SituationPracticeCard';
 import EmptyState from '@/components/studytalk/EmptyState';
 import ChevronLeft from '@/assets/svgs/home/leftarrow.svg';
 
-type TabType = '조음발음' | '상황극';
-type CategoryOption = '전체' | '호흡' | '조음위치' | '조음방법';
-type SortOption = '최신순' | '오래된순';
-
 export default function HomeStudyTalk() {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<TabType>('조음발음');
 
-  // 조음발음 연습용 state
-  const [selectedCategory, setSelectedCategory] = useState<CategoryOption>('전체');
-  const [selectedSort, setSelectedSort] = useState<SortOption>('최신순');
+  // Zustand 스토어에서 상태와 액션 가져오기
+  const activeTab = useStudyTalkStore((state) => state.activeTab);
+  const selectedCategory = useStudyTalkStore((state) => state.selectedCategory);
+  const selectedSort = useStudyTalkStore((state) => state.selectedSort);
+  const selectedSituationCategory = useStudyTalkStore((state) => state.selectedSituationCategory);
+  const selectedSituationSort = useStudyTalkStore((state) => state.selectedSituationSort);
 
-  // 상황극 연습용 state
-  const [selectedSituationCategory, setSelectedSituationCategory] = useState<SituationCategoryOption>('전체');
-  const [selectedSituationSort, setSelectedSituationSort] = useState<SortOption>('최신순');
+  const setActiveTab = useStudyTalkStore((state) => state.setActiveTab);
+  const setSelectedCategory = useStudyTalkStore((state) => state.setCategory);
+  const setSelectedSort = useStudyTalkStore((state) => state.setSort);
+  const setSelectedSituationCategory = useStudyTalkStore((state) => state.setSituationCategory);
+  const setSelectedSituationSort = useStudyTalkStore((state) => state.setSituationSort);
 
   // KIT 카테고리 변환
   const kitCategoryParam = getKitCategoryParam(selectedCategory);
@@ -73,7 +74,7 @@ export default function HomeStudyTalk() {
     return selectedSituationSort === '오래된순' ? [...data].reverse() : data;
   }, [situationBookmarksData, selectedSituationSort]);
 
-  const handleTabChange = (tab: TabType) => {
+  const handleTabChange = (tab: '조음발음' | '상황극') => {
     setActiveTab(tab);
   };
 

--- a/src/stores/useReviewStore.ts
+++ b/src/stores/useReviewStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+
+type CategoryOption = '전체' | '호흡' | '조음위치' | '조음방법';
+type SituationCategoryOption = '전체' | '일상' | '구매' | '의료' | '교통' | '직업' | '사교' | '비상';
+type SortOption = '최신순' | '오래된순';
+
+interface ReviewState {
+  // 조음 키트 복습 필터
+  kitCategory: CategoryOption;
+  kitSort: SortOption;
+
+  // 상황극 복습 필터
+  situationCategory: SituationCategoryOption;
+  situationSort: SortOption;
+}
+
+interface ReviewActions {
+  setKitCategory: (category: CategoryOption) => void;
+  setKitSort: (sort: SortOption) => void;
+  setSituationCategory: (category: SituationCategoryOption) => void;
+  setSituationSort: (sort: SortOption) => void;
+  reset: () => void;
+}
+
+const initialState: ReviewState = {
+  kitCategory: '전체',
+  kitSort: '최신순',
+  situationCategory: '전체',
+  situationSort: '최신순',
+};
+
+export const useReviewStore = create<ReviewState & ReviewActions>((set) => ({
+  ...initialState,
+  setKitCategory: (category) => set({ kitCategory: category }),
+  setKitSort: (sort) => set({ kitSort: sort }),
+  setSituationCategory: (category) => set({ situationCategory: category }),
+  setSituationSort: (sort) => set({ situationSort: sort }),
+  reset: () => set(initialState),
+}));

--- a/src/stores/useSearchStore.ts
+++ b/src/stores/useSearchStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+type TabType = '조음발음' | '상황극';
+
+interface SearchState {
+  activeTab: TabType;
+}
+
+interface SearchActions {
+  setActiveTab: (tab: TabType) => void;
+  reset: () => void;
+}
+
+const initialState: SearchState = {
+  activeTab: '조음발음',
+};
+
+export const useSearchStore = create<SearchState & SearchActions>((set) => ({
+  ...initialState,
+  setActiveTab: (tab) => set({ activeTab: tab }),
+  reset: () => set(initialState),
+}));

--- a/src/stores/useStudyTalkStore.ts
+++ b/src/stores/useStudyTalkStore.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+
+type TabType = '조음발음' | '상황극';
+type CategoryOption = '전체' | '호흡' | '조음위치' | '조음방법';
+type SituationCategoryOption = '전체' | '일상' | '구매' | '의료' | '교통' | '직업' | '사교' | '비상';
+type SortOption = '최신순' | '오래된순';
+
+interface StudyTalkState {
+  // 탭
+  activeTab: TabType;
+
+  // 조음발음 연습 필터
+  selectedCategory: CategoryOption;
+  selectedSort: SortOption;
+
+  // 상황극 연습 필터
+  selectedSituationCategory: SituationCategoryOption;
+  selectedSituationSort: SortOption;
+}
+
+interface StudyTalkActions {
+  setActiveTab: (tab: TabType) => void;
+  setCategory: (category: CategoryOption) => void;
+  setSort: (sort: SortOption) => void;
+  setSituationCategory: (category: SituationCategoryOption) => void;
+  setSituationSort: (sort: SortOption) => void;
+  reset: () => void;
+}
+
+const initialState: StudyTalkState = {
+  activeTab: '조음발음',
+  selectedCategory: '전체',
+  selectedSort: '최신순',
+  selectedSituationCategory: '전체',
+  selectedSituationSort: '최신순',
+};
+
+export const useStudyTalkStore = create<StudyTalkState & StudyTalkActions>((set) => ({
+  ...initialState,
+  setActiveTab: (tab) => set({ activeTab: tab }),
+  setCategory: (category) => set({ selectedCategory: category }),
+  setSort: (sort) => set({ selectedSort: sort }),
+  setSituationCategory: (category) => set({ selectedSituationCategory: category }),
+  setSituationSort: (sort) => set({ selectedSituationSort: sort }),
+  reset: () => set(initialState),
+}));

--- a/src/types/review/queries/dailyStudy.types.ts
+++ b/src/types/review/queries/dailyStudy.types.ts
@@ -1,7 +1,7 @@
 import type { ApiResponse } from '@/types/common/api.types';
 
 export interface DailyStudyItem {
-  type: 'situation' | 'kit';
+  type: 'SITUATION' | 'KIT';
   id: number;
   name: string;
   recordingId: number;

--- a/src/utils/review/feedbackUtils.ts
+++ b/src/utils/review/feedbackUtils.ts
@@ -1,0 +1,50 @@
+interface ParsedFeedback {
+  accuracy: number;
+  fluency: number;
+  completeness: number;
+  prosody: number;
+}
+
+/**
+ * evaluationFeedback 문자열을 파싱하여 객체로 반환
+ * @param feedback - "정확도: 92.0, 유창성: 100.0, 완성도: 100.0, 운율: 95.2" 형식의 문자열
+ * @returns 파싱된 점수 객체
+ */
+export const parseFeedback = (feedback: string): ParsedFeedback => {
+  const accuracyMatch = feedback.match(/정확도:\s*([\d.]+)/);
+  const fluencyMatch = feedback.match(/유창성:\s*([\d.]+)/);
+  const completenessMatch = feedback.match(/완성도:\s*([\d.]+)/);
+  const prosodyMatch = feedback.match(/운율:\s*([\d.]+)/);
+
+  return {
+    accuracy: accuracyMatch ? parseFloat(accuracyMatch[1]) : 0,
+    fluency: fluencyMatch ? parseFloat(fluencyMatch[1]) : 0,
+    completeness: completenessMatch ? parseFloat(completenessMatch[1]) : 0,
+    prosody: prosodyMatch ? parseFloat(prosodyMatch[1]) : 0,
+  };
+};
+
+/**
+ * 여러 레코드의 evaluationFeedback 평균을 계산
+ * @param feedbacks - evaluationFeedback 문자열 배열
+ * @returns 평균 피드백 문자열
+ */
+export const calculateAverageFeedback = (feedbacks: string[]): string => {
+  if (feedbacks.length === 0) return '피드백이 없습니다';
+
+  const totals = feedbacks.reduce(
+    (acc, feedback) => {
+      const parsed = parseFeedback(feedback);
+      return {
+        accuracy: acc.accuracy + parsed.accuracy,
+        fluency: acc.fluency + parsed.fluency,
+        completeness: acc.completeness + parsed.completeness,
+        prosody: acc.prosody + parsed.prosody,
+      };
+    },
+    { accuracy: 0, fluency: 0, completeness: 0, prosody: 0 },
+  );
+
+  const count = feedbacks.length;
+  return `정확도: ${(totals.accuracy / count).toFixed(1)}, 유창성: ${(totals.fluency / count).toFixed(1)}, 완성도: ${(totals.completeness / count).toFixed(1)}, 운율: ${(totals.prosody / count).toFixed(1)}`;
+};

--- a/src/utils/review/index.ts
+++ b/src/utils/review/index.ts
@@ -1,3 +1,4 @@
+export * from './feedbackUtils';
 export * from './kitFilterUtils';
 export * from './kitRouteUtils';
 export * from './situationRouteUtils';


### PR DESCRIPTION
### 🔥 작업 내용 
### 조음 키트 관련
- 현재 호흡 및 발성 키트에서 길게 소리내기 제외하고는 전부 녹음X -> 복습에 안뜨게 해둠.(일단)
### 복습 관련
- 조음키트 복습페이지에서 점수 뜨는 부분이 단어 한개 평가 결과로 출력되고 있음  -> 수정완료

- 조음키트, 상황극 학습 후 복습 페이지로 가면 바로 확인가능하도록 캐시 전략 수정 
ㄴ해결방안 -> 1. 평가 완료시 useInvalidateQuery 2. 복습 관련 쿼리 훅 refetchOnMount : always로 변경
=> 2번으로 해결

- 복습 페이지 (캘린더 포함)에서 재학습 클릭시 경로 오류(상황극) 수정 -> 수정완료
### UI 관련
- 북마크 클릭 시, 애니메이션 효과
### 탭(sort) 관련 
- 페이지 이동해도 상태유지되도록 ux 개선 -> zustand 사용

### 선택 상태 유지
- 홈 → 내 학습 → 홈 → 내 학습: 탭과 필터 선택 유지됨
- 페이지 이동 후 뒤로가기: 선택 상태 유지됨
- 사용자가 필터를 변경하면 해당 상태가 앱 내에서 계속 유지
### 초기화 시점
- 브라우저 새로고침: 초기 상태로 리셋
- 앱 종료 후 재방문: 초기 상태로 리셋
- 너무 오래 유지되지 않아서 사용자 혼란x

### 자유대화
- 아바타 질문 다 듣고 대답하라는 모달 추가

### 🔗 관련 이슈
- #52 
